### PR TITLE
Add first pass zsh configuration

### DIFF
--- a/link.sh
+++ b/link.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 THIS_DIR=`dirname $0`
-cd $THIS_DIR 
+cd $THIS_DIR
 SRC_DIR=`pwd`
 
 # TMUX
@@ -14,3 +14,6 @@ ln -sv $SRC_DIR/gitconfig ~/.gitconfig
 # Bash Profile
 ln -sv $SRC_DIR/bash_profile ~/.bash_profile
 
+# ZSH
+ln -sv $SRC_DIR/zsh/.zshenv ~/.zshenv
+ln -sv $SRC_DIR/.hushlogin ~/.hushlogin

--- a/zsh/.gitignore
+++ b/zsh/.gitignore
@@ -1,0 +1,2 @@
+.zcompdump*
+.zsh_history

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,0 +1,1 @@
+ZDOTDIR=~/src/compy-config/zsh

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,0 +1,139 @@
+# Path changes
+export PATH=~/bin:/usr/local/bin:/usr/local/sbin:$PATH
+export PATH="$PATH:/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
+
+# Brew completions - now packaged with brew, not in oh-my-zsh
+if type brew &>/dev/null; then
+  FPATH=$(brew --prefix)/share/zsh/site-functions:$FPATH
+fi
+
+# Haskell
+export PATH=~/.local/bin:$PATH
+# Node version manager (NVM)
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+
+# Rust
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# virtualenvwrapper
+export WORKON_HOME=~/.virtualenvs
+source /usr/local/bin/virtualenvwrapper.sh
+
+# zsh shell correction settings
+setopt CORRECT
+setopt CORRECT_ALL
+
+# zsh shell history settings
+HISTFILE=$HOME/.zsh_history
+SAVEHIST=1000
+HISTSIZE=2000
+setopt APPEND_HISTORY
+setopt INC_APPEND_HISTORY
+setopt SHARE_HISTORY
+setopt HIST_EXPIRE_DUPS_FIRST
+setopt HIST_IGNORE_DUPS
+setopt HIST_REDUCE_BLANKS
+setopt HIST_VERIFY
+
+# Path to your oh-my-zsh installation.
+export ZSH="$HOME/.oh-my-zsh"
+
+# Set name of the theme to load --- if set to "random", it will
+# load a random theme each time oh-my-zsh is loaded, in which case,
+# to know which specific one was loaded, run: echo $RANDOM_THEME
+# See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
+ZSH_THEME="robbyrussell"
+
+# Set list of themes to pick from when loading at random
+# Setting this variable when ZSH_THEME=random will cause zsh to load
+# a theme from this variable instead of looking in ~/.oh-my-zsh/themes/
+# If set to an empty array, this variable will have no effect.
+# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
+
+# Uncomment the following line to use case-sensitive completion.
+# CASE_SENSITIVE="true"
+
+# Uncomment the following line to use hyphen-insensitive completion.
+# Case-sensitive completion must be off. _ and - will be interchangeable.
+# HYPHEN_INSENSITIVE="true"
+
+# Uncomment the following line to disable bi-weekly auto-update checks.
+# DISABLE_AUTO_UPDATE="true"
+
+# Uncomment the following line to automatically update without prompting.
+# DISABLE_UPDATE_PROMPT="true"
+
+# Uncomment the following line to change how often to auto-update (in days).
+export UPDATE_ZSH_DAYS=30
+
+# Uncomment the following line if pasting URLs and other text is messed up.
+# DISABLE_MAGIC_FUNCTIONS=true
+
+# Uncomment the following line to disable colors in ls.
+# DISABLE_LS_COLORS="true"
+
+# Uncomment the following line to disable auto-setting terminal title.
+# DISABLE_AUTO_TITLE="true"
+
+# Uncomment the following line to enable command auto-correction.
+# ENABLE_CORRECTION="true"
+
+# Uncomment the following line to display red dots whilst waiting for completion.
+# COMPLETION_WAITING_DOTS="true"
+
+# Uncomment the following line if you want to disable marking untracked files
+# under VCS as dirty. This makes repository status check for large repositories
+# much, much faster.
+DISABLE_UNTRACKED_FILES_DIRTY="true"
+
+# Uncomment the following line if you want to change the command execution time
+# stamp shown in the history command output.
+# You can set one of the optional three formats:
+# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# or set a custom format using the strftime function format specifications,
+# see 'man strftime' for details.
+# HIST_STAMPS="mm/dd/yyyy"
+
+# Would you like to use another custom folder than $ZSH/custom?
+ZSH_CUSTOM=$HOME/src/compy-config/zsh/zsh-custom
+
+# Which plugins would you like to load?
+# Standard plugins can be found in ~/.oh-my-zsh/plugins/*
+# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
+# Example format: plugins=(rails git textmate ruby lighthouse)
+# Add wisely, as too many plugins slow down shell startup.
+# You may need to delete ZDOTDIR/.zcompdump* after adding an autocomplete plugin
+# to include its changes.
+plugins=(aws docker git httpie nvm osx virtualenvwrapper vscode)
+
+source $ZSH/oh-my-zsh.sh
+
+# User configuration
+
+# export MANPATH="/usr/local/man:$MANPATH"
+
+# You may need to manually set your language environment
+# export LANG=en_US.UTF-8
+
+# Preferred editor for local and remote sessions
+# if [[ -n $SSH_CONNECTION ]]; then
+#   export EDITOR='vim'
+# else
+#   export EDITOR='mvim'
+# fi
+
+# Compilation flags
+# export ARCHFLAGS="-arch x86_64"
+
+# Set personal aliases, overriding those provided by oh-my-zsh libs,
+# plugins, and themes. Aliases can be placed here, though oh-my-zsh
+# users are encouraged to define aliases within the ZSH_CUSTOM folder.
+# For a full list of active aliases, run `alias`.
+#
+# Example aliases
+# alias zshconfig="mate ~/.zshrc"
+# alias ohmyzsh="mate ~/.oh-my-zsh"
+alias vup="vagrant up"
+alias vssh="vagrant ssh"
+alias http-jwt="http --auth-type=jwt"

--- a/zsh/README.md
+++ b/zsh/README.md
@@ -1,0 +1,8 @@
+# zsh shell configuration
+
+To install:
+
+- Run `link.sh` in the parent directory to point zsh to this dir via `.zshenv`
+- Run `./install-ohmyzsh-YYYYMMDD.sh` to install ohmyzsh to default location (in home dir)
+
+Restart terminal to source changes.

--- a/zsh/install-ohmyzsh-20191215.sh
+++ b/zsh/install-ohmyzsh-20191215.sh
@@ -1,0 +1,281 @@
+#!/bin/sh
+#
+# This script should be run via curl:
+#   sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+# or wget:
+#   sh -c "$(wget -qO- https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+#
+# As an alternative, you can first download the install script and run it afterwards:
+#   wget https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh
+#   sh install.sh
+#
+# You can tweak the install behavior by setting variables when running the script. For
+# example, to change the path to the Oh My Zsh repository:
+#   ZSH=~/.zsh sh install.sh
+#
+# Respects the following environment variables:
+#   ZSH     - path to the Oh My Zsh repository folder (default: $HOME/.oh-my-zsh)
+#   REPO    - name of the GitHub repo to install from (default: ohmyzsh/ohmyzsh)
+#   REMOTE  - full remote URL of the git repo to install (default: GitHub via HTTPS)
+#   BRANCH  - branch to check out immediately after install (default: master)
+#
+# Other options:
+#   CHSH    - 'no' means the installer will not change the default shell (default: yes)
+#   RUNZSH  - 'no' means the installer will not run zsh after the install (default: yes)
+#
+# You can also pass some arguments to the install script to set some these options:
+#   --skip-chsh: has the same behavior as setting CHSH to 'no'
+#   --unattended: sets both CHSH and RUNZSH to 'no'
+# For example:
+#   sh install.sh --unattended
+#
+set -e
+
+# Default settings
+ZSH=${ZSH:-~/.oh-my-zsh}
+REPO=${REPO:-ohmyzsh/ohmyzsh}
+REMOTE=${REMOTE:-https://github.com/${REPO}.git}
+BRANCH=${BRANCH:-master}
+
+# Other options
+CHSH=${CHSH:-yes}
+RUNZSH=${RUNZSH:-yes}
+
+
+command_exists() {
+	command -v "$@" >/dev/null 2>&1
+}
+
+error() {
+	echo ${RED}"Error: $@"${RESET} >&2
+}
+
+setup_color() {
+	# Only use colors if connected to a terminal
+	if [ -t 1 ]; then
+		RED=$(printf '\033[31m')
+		GREEN=$(printf '\033[32m')
+		YELLOW=$(printf '\033[33m')
+		BLUE=$(printf '\033[34m')
+		BOLD=$(printf '\033[1m')
+		RESET=$(printf '\033[m')
+	else
+		RED=""
+		GREEN=""
+		YELLOW=""
+		BLUE=""
+		BOLD=""
+		RESET=""
+	fi
+}
+
+setup_ohmyzsh() {
+	# Prevent the cloned repository from having insecure permissions. Failing to do
+	# so causes compinit() calls to fail with "command not found: compdef" errors
+	# for users with insecure umasks (e.g., "002", allowing group writability). Note
+	# that this will be ignored under Cygwin by default, as Windows ACLs take
+	# precedence over umasks except for filesystems mounted with option "noacl".
+	umask g-w,o-w
+
+	echo "${BLUE}Cloning Oh My Zsh...${RESET}"
+
+	command_exists git || {
+		error "git is not installed"
+		exit 1
+	}
+
+	if [ "$OSTYPE" = cygwin ] && git --version | grep -q msysgit; then
+		error "Windows/MSYS Git is not supported on Cygwin"
+		error "Make sure the Cygwin git package is installed and is first on the \$PATH"
+		exit 1
+	fi
+
+	git clone -c core.eol=lf -c core.autocrlf=false \
+		-c fsck.zeroPaddedFilemode=ignore \
+		-c fetch.fsck.zeroPaddedFilemode=ignore \
+		-c receive.fsck.zeroPaddedFilemode=ignore \
+		--depth=1 --branch "$BRANCH" "$REMOTE" "$ZSH" || {
+		error "git clone of oh-my-zsh repo failed"
+		exit 1
+	}
+
+	echo
+}
+
+setup_zshrc() {
+	# Keep most recent old .zshrc at .zshrc.pre-oh-my-zsh, and older ones
+	# with datestamp of installation that moved them aside, so we never actually
+	# destroy a user's original zshrc
+	echo "${BLUE}Looking for an existing zsh config...${RESET}"
+
+	# Must use this exact name so uninstall.sh can find it
+	OLD_ZSHRC=~/.zshrc.pre-oh-my-zsh
+	if [ -f ~/.zshrc ] || [ -h ~/.zshrc ]; then
+		if [ -e "$OLD_ZSHRC" ]; then
+			OLD_OLD_ZSHRC="${OLD_ZSHRC}-$(date +%Y-%m-%d_%H-%M-%S)"
+			if [ -e "$OLD_OLD_ZSHRC" ]; then
+				error "$OLD_OLD_ZSHRC exists. Can't back up ${OLD_ZSHRC}"
+				error "re-run the installer again in a couple of seconds"
+				exit 1
+			fi
+			mv "$OLD_ZSHRC" "${OLD_OLD_ZSHRC}"
+
+			echo "${YELLOW}Found old ~/.zshrc.pre-oh-my-zsh." \
+				"${GREEN}Backing up to ${OLD_OLD_ZSHRC}${RESET}"
+		fi
+		echo "${YELLOW}Found ~/.zshrc.${RESET} ${GREEN}Backing up to ${OLD_ZSHRC}${RESET}"
+		mv ~/.zshrc "$OLD_ZSHRC"
+	fi
+
+	echo "${GREEN}Using the Oh My Zsh template file and adding it to ~/.zshrc.${RESET}"
+
+	cp "$ZSH/templates/zshrc.zsh-template" ~/.zshrc
+	sed "/^export ZSH=/ c\\
+export ZSH=\"$ZSH\"
+" ~/.zshrc > ~/.zshrc-omztemp
+	mv -f ~/.zshrc-omztemp ~/.zshrc
+
+	echo
+}
+
+setup_shell() {
+	# Skip setup if the user wants or stdin is closed (not running interactively).
+	if [ $CHSH = no ]; then
+		return
+	fi
+
+	# If this user's login shell is already "zsh", do not attempt to switch.
+	if [ "$(basename "$SHELL")" = "zsh" ]; then
+		return
+	fi
+
+	# If this platform doesn't provide a "chsh" command, bail out.
+	if ! command_exists chsh; then
+		cat <<-EOF
+			I can't change your shell automatically because this system does not have chsh.
+			${BLUE}Please manually change your default shell to zsh${RESET}
+		EOF
+		return
+	fi
+
+	echo "${BLUE}Time to change your default shell to zsh:${RESET}"
+
+	# Prompt for user choice on changing the default login shell
+	printf "${YELLOW}Do you want to change your default shell to zsh? [Y/n]${RESET} "
+	read opt
+	case $opt in
+		y*|Y*|"") echo "Changing the shell..." ;;
+		n*|N*) echo "Shell change skipped."; return ;;
+		*) echo "Invalid choice. Shell change skipped."; return ;;
+	esac
+
+	# Check if we're running on Termux
+	case "$PREFIX" in
+		*com.termux*) termux=true; zsh=zsh ;;
+		*) termux=false ;;
+	esac
+
+	if [ "$termux" != true ]; then
+		# Test for the right location of the "shells" file
+		if [ -f /etc/shells ]; then
+			shells_file=/etc/shells
+		elif [ -f /usr/share/defaults/etc/shells ]; then # Solus OS
+			shells_file=/usr/share/defaults/etc/shells
+		else
+			error "could not find /etc/shells file. Change your default shell manually."
+			return
+		fi
+
+		# Get the path to the right zsh binary
+		# 1. Use the most preceding one based on $PATH, then check that it's in the shells file
+		# 2. If that fails, get a zsh path from the shells file, then check it actually exists
+		if ! zsh=$(which zsh) || ! grep -qx "$zsh" "$shells_file"; then
+			if ! zsh=$(grep '^/.*/zsh$' "$shells_file" | tail -1) || [ ! -f "$zsh" ]; then
+				error "no zsh binary found or not present in '$shells_file'"
+				error "change your default shell manually."
+				return
+			fi
+		fi
+	fi
+
+	# We're going to change the default shell, so back up the current one
+	if [ -n "$SHELL" ]; then
+		echo $SHELL > ~/.shell.pre-oh-my-zsh
+	else
+		grep "^$USER:" /etc/passwd | awk -F: '{print $7}' > ~/.shell.pre-oh-my-zsh
+	fi
+
+	# Actually change the default shell to zsh
+	if ! chsh -s "$zsh"; then
+		error "chsh command unsuccessful. Change your default shell manually."
+	else
+		export SHELL="$zsh"
+		echo "${GREEN}Shell successfully changed to '$zsh'.${RESET}"
+	fi
+
+	echo
+}
+
+main() {
+	# Run as unattended if stdin is closed
+	if [ ! -t 0 ]; then
+		RUNZSH=no
+		CHSH=no
+	fi
+
+	# Parse arguments
+	while [ $# -gt 0 ]; do
+		case $1 in
+			--unattended) RUNZSH=no; CHSH=no ;;
+			--skip-chsh) CHSH=no ;;
+		esac
+		shift
+	done
+
+	setup_color
+
+	if ! command_exists zsh; then
+		echo "${YELLOW}Zsh is not installed.${RESET} Please install zsh first."
+		exit 1
+	fi
+
+	if [ -d "$ZSH" ]; then
+		cat <<-EOF
+			${YELLOW}You already have Oh My Zsh installed.${RESET}
+			You'll need to remove '$ZSH' if you want to reinstall.
+		EOF
+		exit 1
+	fi
+
+	setup_ohmyzsh
+	setup_zshrc
+	setup_shell
+
+	printf "$GREEN"
+	cat <<-'EOF'
+		         __                                     __
+		  ____  / /_     ____ ___  __  __   ____  _____/ /_
+		 / __ \/ __ \   / __ `__ \/ / / /  /_  / / ___/ __ \
+		/ /_/ / / / /  / / / / / / /_/ /    / /_(__  ) / / /
+		\____/_/ /_/  /_/ /_/ /_/\__, /    /___/____/_/ /_/
+		                        /____/                       ....is now installed!
+
+
+		Please look over the ~/.zshrc file to select plugins, themes, and options.
+
+		p.s. Follow us on https://twitter.com/ohmyzsh
+
+		p.p.s. Get stickers, shirts, and coffee mugs at https://shop.planetargon.com/collections/oh-my-zsh
+
+	EOF
+	printf "$RESET"
+
+	if [ $RUNZSH = no ]; then
+		echo "${YELLOW}Run zsh to try it out.${RESET}"
+		exit
+	fi
+
+	exec zsh -l
+}
+
+main "$@"

--- a/zsh/zsh-custom/themes/robbyrussell.zsh-theme
+++ b/zsh/zsh-custom/themes/robbyrussell.zsh-theme
@@ -1,0 +1,7 @@
+PROMPT="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ )"
+PROMPT+=' %{$fg[cyan]%}%~%{$reset_color%} $(git_prompt_info)'
+
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}git:(%{$fg[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%})"


### PR DESCRIPTION
Uses oh-my-zsh to configure some useful plugins

ZSH_CUSTOM and ZDOTDIR are statically set to
`~/src/compy-config`, this could be optimized
to be figured out automatically.

Initial theme is a custom version of "robbyrussell"
that tweaks path display to be full path. Otherwise
I get lost.